### PR TITLE
Fix failing test

### DIFF
--- a/src/test/scala/TestSpec.scala
+++ b/src/test/scala/TestSpec.scala
@@ -8,6 +8,7 @@ import scala.concurrent.duration._
 
 class TestSpec extends AsyncWordSpec {
   implicit val ec = Scheduler.trampoline(executionModel = AlwaysAsyncExecution)
+  override def executionContext = ec
   val task = Task(1)
 
   "A task" should {


### PR DESCRIPTION
This isn't monix-specific. Checking stack trace clearly says the error comes from ScalaTest:
```
[info] - should execute fine when delayed *** FAILED ***
[info]   java.lang.IllegalStateException: Queue is empty while futur
e is not completed, this means you're probably using a wrong Executi
onContext for your task, please double check your Future.
[info]   at $c_jl_IllegalStateException.$c_jl_Throwable.fillInStackT
race__jl_Throwable(C:\media\ren\dos\code\Scala-js-monix-delayed-task
-test\target\scala-2.12\scala-js-monix-delayed-task-test-test-fastop
t.js:26006:14)
[info]   at $c_jl_IllegalStateException.$c_jl_Throwable.init___T__jl
_Throwable__Z__Z(C:\media\ren\dos\code\Scala-js-monix-delayed-task-t
est\target\scala-2.12\scala-js-monix-delayed-task-test-test-fastopt.
js:26124:10)
[info]   at java.lang.IllegalStateException.<init>(C:\media\ren\dos\
code\Scala-js-monix-delayed-task-test\target\scala-2.12\scala-js-mon
ix-delayed-task-test-test-fastopt.js:43106:58)
[info]   at org.scalatest.concurrent.SerialExecutionContext.recRunNo
w(C:\media\ren\dos\code\Scala-js-monix-delayed-task-test\target\scal
a-2.12\scala-js-monix-delayed-task-test-test-fastopt.js:24012:49)
```

To fix it, you need to tell ScalaTest to use same EC for itself as your tests do by overriding it in the class. Since `Scheduler` is an EC, it's fairly straightforward:
```scala
  override def executionContext = ec
```